### PR TITLE
fix: catch malformed JSON

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,14 @@ const main = async () => {
   })
   const pkgs = {}
   for (const entry of entries) {
-    const pkg = JSON.parse(await fs.readFile(entry.fullPath))
+    const entryBuffer = await fs.readFile(entry.fullPath)
+    let pkg
+    try {
+      pkg = JSON.parse(entryBuffer)
+    } catch (err) {
+      //malformed JSON, skip this entry
+      continue
+    }
     if (!pkg.version) continue
     pkg.fullPath = entry.fullPath
     if (!pkgs[pkg.name] || semver.lt(pkgs[pkg.name].version, pkg.version)) {


### PR DESCRIPTION
Some libraries have intentionally malformed package.json (e.g. resolve's malformed_package_json).
This skips any packages with malformed JSON and carries on.

Fixes issue #15 